### PR TITLE
Make it easy to change config file path

### DIFF
--- a/cloudflare-sync-ips.sh
+++ b/cloudflare-sync-ips.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
-echo "#Cloudflare" > /etc/nginx/cloudflare;
-echo "" >> /etc/nginx/cloudflare;
 
-echo "# - IPv4" >> /etc/nginx/cloudflare;
+CLOUDFLARE_FILE_PATH=/etc/nginx/cloudflare
+
+echo "#Cloudflare" > $CLOUDFLARE_FILE_PATH;
+echo "" >> $CLOUDFLARE_FILE_PATH;
+
+echo "# - IPv4" >> $CLOUDFLARE_FILE_PATH;
 for i in `curl https://www.cloudflare.com/ips-v4`; do
-        echo "set_real_ip_from $i;" >> /etc/nginx/cloudflare;
+        echo "set_real_ip_from $i;" >> $CLOUDFLARE_FILE_PATH;
 done
 
-echo "" >> /etc/nginx/cloudflare;
-echo "# - IPv6" >> /etc/nginx/cloudflare;
+echo "" >> $CLOUDFLARE_FILE_PATH;
+echo "# - IPv6" >> $CLOUDFLARE_FILE_PATH;
 for i in `curl https://www.cloudflare.com/ips-v6`; do
-        echo "set_real_ip_from $i;" >> /etc/nginx/cloudflare;
+        echo "set_real_ip_from $i;" >> $CLOUDFLARE_FILE_PATH;
 done
 
-echo "" >> /etc/nginx/cloudflare;
-echo "real_ip_header CF-Connecting-IP;" >> /etc/nginx/cloudflare;
+echo "" >> $CLOUDFLARE_FILE_PATH;
+echo "real_ip_header CF-Connecting-IP;" >> $CLOUDFLARE_FILE_PATH;
 
 #test configuration and reload nginx
 nginx -t && systemctl reload nginx


### PR DESCRIPTION
Personally I would place this in `/etc/nginx/snippets`, as this is where snippets like this should reside.
With this change it makes it easy to change the file location path, without introducing breaking changes (without changing config file path).