### PR TITLE
Allow overriding of default path by argument

### DIFF
--- a/cloudflare-sync-ips.sh
+++ b/cloudflare-sync-ips.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CLOUDFLARE_FILE_PATH=/etc/nginx/cloudflare
+CLOUDFLARE_FILE_PATH=${1:-/etc/nginx/cloudflare}
 
 echo "#Cloudflare" > $CLOUDFLARE_FILE_PATH;
 echo "" >> $CLOUDFLARE_FILE_PATH;


### PR DESCRIPTION
Will process first argument of script as the path to write to. If left out it will default to `/etc/nginx/cloudflare`