### PR TITLE
Use Cloudflare API instead of Website

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The bash script may run manually or can be scheduled to refresh the ip list of C
 #!/bin/bash
 
 cf_ips="$(curl -fsLm2 --retry 1 https://api.cloudflare.com/client/v4/ips)"
-CLOUDFLARE_FILE_PATH="/etc/nginx/cloudflare"
+CLOUDFLARE_FILE_PATH=${1:-/etc/nginx/cloudflare}
 
 echo "# Cloudflare IP Ranges" > $CLOUDFLARE_FILE_PATH
 echo "" >> $CLOUDFLARE_FILE_PATH

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ This project aims to modify your nginx configuration to let you get the real ip 
 
 To provide the client (visitor) IP address for every request to the origin, Cloudflare adds the "CF-Connecting-IP" header. We will catch the header and get the real ip address of the visitor.
 
+## Install 
+
+`apt-get install jq` or ` dnf install jq`
+
 ## Nginx Configuration
 With a small configuration modification we can integrate replacing the real ip address of the visitor instead of getting CloudFlare's load balancers' ip addresses.
 
@@ -16,24 +20,21 @@ The bash script may run manually or can be scheduled to refresh the ip list of C
 ```sh
 #!/bin/bash
 
-CLOUDFLARE_FILE_PATH=/etc/nginx/cloudflare
+CLOUDFLARE_FILE_PATH="/etc/nginx/cloudflare"
 
-echo "#Cloudflare" > $CLOUDFLARE_FILE_PATH;
-echo "" >> $CLOUDFLARE_FILE_PATH;
-
-echo "# - IPv4" >> $CLOUDFLARE_FILE_PATH;
-for i in `curl -s -L https://www.cloudflare.com/ips-v4`; do
-    echo "set_real_ip_from $i;" >> $CLOUDFLARE_FILE_PATH;
+echo "# Cloudflare IP Ranges" > $CLOUDFLARE_FILE_PATH
+echo "" >> $CLOUDFLARE_FILE_PATH
+echo "# - IPv4" >> $CLOUDFLARE_FILE_PATH
+for ipv4 in $(echo "$cf_ips" | jq -r '.result.ipv4_cidrs[]//""' | sort); do
+	echo "set_real_ip_from $ipv4;" >> $CLOUDFLARE_FILE_PATH
 done
-
-echo "" >> $CLOUDFLARE_FILE_PATH;
-echo "# - IPv6" >> $CLOUDFLARE_FILE_PATH;
-for i in `curl -s -L https://www.cloudflare.com/ips-v6`; do
-    echo "set_real_ip_from $i;" >> $CLOUDFLARE_FILE_PATH;
-done
-
-echo "" >> $CLOUDFLARE_FILE_PATH;
-echo "real_ip_header CF-Connecting-IP;" >> $CLOUDFLARE_FILE_PATH;
+echo "" >> $CLOUDFLARE_FILE_PATH
+echo "# - IPv6" >> $CLOUDFLARE_FILE_PATH
+for ipv6 in $(echo "$cf_ips" | jq -r '.result.ipv6_cidrs[]//""' | sort); do
+    echo "set_real_ip_from $ipv6;" >> $CLOUDFLARE_FILE_PATH
+ done
+ echo "" >> $CLOUDFLARE_FILE_PATH
+ echo "real_ip_header CF-Connecting-IP;" >> $CLOUDFLARE_FILE_PATH
 
 #test configuration and reload nginx
 nginx -t && systemctl reload nginx

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The bash script may run manually or can be scheduled to refresh the ip list of C
 ```sh
 #!/bin/bash
 
+cf_ips="$(curl -fsLm2 --retry 1 https://api.cloudflare.com/client/v4/ips)"
 CLOUDFLARE_FILE_PATH="/etc/nginx/cloudflare"
 
 echo "# Cloudflare IP Ranges" > $CLOUDFLARE_FILE_PATH

--- a/cloudflare-sync-ips.sh
+++ b/cloudflare-sync-ips.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cf_ips="$(curl -fsLm2 --retry 1 https://api.cloudflare.com/client/v4/ips)"
-CLOUDFLARE_FILE_PATH="/etc/nginx/cloudflare"
+CLOUDFLARE_FILE_PATH=${1:-/etc/nginx/cloudflare}
 
 echo "# Cloudflare IP Ranges" > $CLOUDFLARE_FILE_PATH
 echo "" >> $CLOUDFLARE_FILE_PATH

--- a/cloudflare-sync-ips.sh
+++ b/cloudflare-sync-ips.sh
@@ -1,23 +1,20 @@
 #!/bin/bash
 
-CLOUDFLARE_FILE_PATH=${1:-/etc/nginx/cloudflare}
+CLOUDFLARE_FILE_PATH="/etc/nginx/cloudflare"
 
-echo "#Cloudflare" > $CLOUDFLARE_FILE_PATH;
-echo "" >> $CLOUDFLARE_FILE_PATH;
-
-echo "# - IPv4" >> $CLOUDFLARE_FILE_PATH;
-for i in `curl -s -L https://www.cloudflare.com/ips-v4`; do
-        echo "set_real_ip_from $i;" >> $CLOUDFLARE_FILE_PATH;
+echo "# Cloudflare IP Ranges" > $CLOUDFLARE_FILE_PATH
+echo "" >> $CLOUDFLARE_FILE_PATH
+echo "# - IPv4" >> $CLOUDFLARE_FILE_PATH
+for ipv4 in $(echo "$cf_ips" | jq -r '.result.ipv4_cidrs[]//""' | sort); do
+	echo "set_real_ip_from $ipv4;" >> $CLOUDFLARE_FILE_PATH
 done
-
-echo "" >> $CLOUDFLARE_FILE_PATH;
-echo "# - IPv6" >> $CLOUDFLARE_FILE_PATH;
-for i in `curl -s -L https://www.cloudflare.com/ips-v6`; do
-        echo "set_real_ip_from $i;" >> $CLOUDFLARE_FILE_PATH;
-done
-
-echo "" >> $CLOUDFLARE_FILE_PATH;
-echo "real_ip_header CF-Connecting-IP;" >> $CLOUDFLARE_FILE_PATH;
+echo "" >> $CLOUDFLARE_FILE_PATH
+echo "# - IPv6" >> $CLOUDFLARE_FILE_PATH
+for ipv6 in $(echo "$cf_ips" | jq -r '.result.ipv6_cidrs[]//""' | sort); do
+    echo "set_real_ip_from $ipv6;" >> $CLOUDFLARE_FILE_PATH
+ done
+ echo "" >> $CLOUDFLARE_FILE_PATH
+ echo "real_ip_header CF-Connecting-IP;" >> $CLOUDFLARE_FILE_PATH
 
 #test configuration and reload nginx
 nginx -t && systemctl reload nginx

--- a/cloudflare-sync-ips.sh
+++ b/cloudflare-sync-ips.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+cf_ips="$(curl -fsLm2 --retry 1 https://api.cloudflare.com/client/v4/ips)"
 CLOUDFLARE_FILE_PATH="/etc/nginx/cloudflare"
 
 echo "# Cloudflare IP Ranges" > $CLOUDFLARE_FILE_PATH


### PR DESCRIPTION
Cloudflare Website might show a random check if the visitor is a real user instead of a bot this causes the old system to fail

See: https://github.com/hestiacp/hestiacp/issues/3370

Option would be to use the https://api.cloudflare.com/client/v4/ips how ever it will add a dependency on jq a 200kb tools of phrasing json files. 

The API it self is free to use and it has been tested in the last 2 days since then no complains about the changes

Also @myrevery to contribute to the PR it self. 